### PR TITLE
子供一覧画面

### DIFF
--- a/src/app/children/page.tsx
+++ b/src/app/children/page.tsx
@@ -1,35 +1,116 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { apiFetch, ApiError } from "@/lib/api";
 import { clearToken, getToken } from "@/lib/auth";
+import type { Child } from "@/types/child";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+type ErrorInfo = {
+  message: string;
+};
 
 export default function ChildrenPage() {
   const router = useRouter();
-  const [ready, setReady] = useState(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const [children, setChildren] = useState<Child[]>([]);
+  const [error, setError] = useState<ErrorInfo | null>(null);
+
+  const token = useMemo(() => getToken(), []);
+
+  const fetchChildren = useCallback(async () => {
+    if (!token) {
+      return;
+    }
+    setStatus("loading");
+    setError(null);
+
+    try {
+      const data = await apiFetch<Child[]>("/children", { token });
+      setChildren(data);
+      setStatus("success");
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        clearToken();
+        router.replace("/login");
+        return;
+      }
+
+      const message =
+        err instanceof Error
+          ? err.message
+          : "原因不明のエラーが発生しました";
+      setError({ message });
+      setStatus("error");
+    }
+  }, [router, token]);
 
   useEffect(() => {
-    const token = getToken();
     if (!token) {
       router.replace("/login");
       return;
     }
-    setReady(true);
-  }, [router]);
+    void fetchChildren();
+  }, [fetchChildren, router, token]);
 
   const handleLogout = () => {
     clearToken();
     router.replace("/login");
   };
 
-  if (!ready) {
-    return null;
-  }
-
   return (
     <div style={{ padding: "40px" }}>
-      <h1>ログイン中</h1>
-      <button onClick={handleLogout}>Logout</button>
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "24px",
+          gap: "12px",
+        }}
+      >
+        <h1 style={{ margin: 0 }}>子供一覧</h1>
+        <button onClick={handleLogout}>Logout</button>
+      </header>
+
+      {status === "loading" && <p>Loading...</p>}
+
+      {status === "error" && (
+        <div style={{ display: "grid", gap: "12px" }}>
+          <p>
+            読み込みに失敗しました: {error?.message ?? "不明なエラー"}
+          </p>
+          <button onClick={fetchChildren}>再試行</button>
+        </div>
+      )}
+
+      {status === "success" && children.length === 0 && (
+        <p>子供がまだ登録されていません</p>
+      )}
+
+      {status === "success" && children.length > 0 && (
+        <div style={{ display: "grid", gap: "12px" }}>
+          {children.map((child) => (
+            <div
+              key={child.id}
+              style={{
+                border: "1px solid #e2e8f0",
+                borderRadius: "8px",
+                padding: "12px 16px",
+              }}
+            >
+              <h2 style={{ margin: "0 0 4px", fontSize: "16px" }}>
+                {child.name}
+              </h2>
+              <p style={{ margin: 0, color: "#475569" }}>
+                学年: {child.grade ?? "未設定"}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/types/child.ts
+++ b/src/types/child.ts
@@ -1,0 +1,6 @@
+export type Child = {
+  id: string;
+  name: string;
+  grade?: string | null;
+  is_active?: boolean;
+};


### PR DESCRIPTION
## 概要
/children 画面で子供一覧を API から取得して表示できるようにしました。

## 変更内容
- `/children` で `GET /children` を呼び出し、一覧を表示
- ローディング/空/エラー/成功の表示を分岐
- 401 の場合は token をクリアして `/login` にリダイレクト
- 「再試行」ボタンで再取得できるように対応
- Child 型を追加（src/types/child.ts）

## 動作確認
- /login でログイン後 /children で一覧が表示されること
- 0件の場合に「未登録」メッセージが出ること
- token無しで /children へ行くと /login に戻ること
- 401時に token が消えて /login に戻ること