### PR TITLE
「今日の学習」画面

### DIFF
--- a/src/app/children/[childId]/daily/page.tsx
+++ b/src/app/children/[childId]/daily/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { apiFetch, ApiError } from "@/lib/api";
+import { clearToken, getToken } from "@/lib/auth";
+
+type DailyTask = {
+  task_id: string;
+  subject: string;
+  name: string;
+  minutes: number;
+  is_done: boolean;
+};
+
+type DailyView = {
+  tasks: DailyTask[];
+};
+
+type TaskState = DailyTask & {
+  checked: boolean;
+};
+
+type Status = "idle" | "loading" | "success" | "error";
+
+type ErrorInfo = {
+  message: string;
+};
+
+export default function DailyPage() {
+  const router = useRouter();
+  const params = useParams();
+  const childId = params?.childId;
+  const token = useMemo(() => getToken(), []);
+  const today = useMemo(() => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = `${now.getMonth() + 1}`.padStart(2, "0");
+    const day = `${now.getDate()}`.padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }, []);
+
+  const [status, setStatus] = useState<Status>("idle");
+  const [tasks, setTasks] = useState<TaskState[]>([]);
+  const [error, setError] = useState<ErrorInfo | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const fetchDaily = useCallback(async () => {
+    if (!token || typeof childId !== "string") {
+      return;
+    }
+    setStatus("loading");
+    setError(null);
+
+    try {
+      const data = await apiFetch<DailyView>(
+        `/children/${childId}/daily-view?date=${today}`,
+        { token }
+      );
+      const nextTasks = (data.tasks ?? []).map((task) => ({
+        ...task,
+        checked: task.is_done,
+      }));
+      setTasks(nextTasks);
+      setStatus("success");
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        clearToken();
+        router.replace("/login");
+        return;
+      }
+      const message =
+        err instanceof Error
+          ? err.message
+          : "原因不明のエラーが発生しました";
+      setError({ message });
+      setStatus("error");
+    }
+  }, [childId, router, today, token]);
+
+  useEffect(() => {
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+
+    if (typeof childId !== "string") {
+      setError({ message: "子供IDが不正です" });
+      setStatus("error");
+      return;
+    }
+
+    void fetchDaily();
+  }, [childId, fetchDaily, router, token]);
+
+  const handleToggle = (taskId: string) => {
+    setTasks((prev) =>
+      prev.map((task) =>
+        task.task_id === taskId
+          ? { ...task, checked: !task.checked }
+          : task
+      )
+    );
+  };
+
+  const handleMinutesChange = (taskId: string, value: string) => {
+    const minutes = Number(value);
+    if (Number.isNaN(minutes)) {
+      return;
+    }
+    setTasks((prev) =>
+      prev.map((task) =>
+        task.task_id === taskId ? { ...task, minutes } : task
+      )
+    );
+  };
+
+  const handleSave = async () => {
+    if (!token || typeof childId !== "string") {
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+
+    try {
+      const items = tasks
+        .filter((task) => task.checked)
+        .map((task) => ({
+          task_id: task.task_id,
+          minutes: task.minutes,
+        }));
+
+      await apiFetch(`/children/${childId}/daily?date=${today}`, {
+        method: "PUT",
+        token,
+        body: { items },
+      });
+
+      await fetchDaily();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        clearToken();
+        router.replace("/login");
+        return;
+      }
+      const message =
+        err instanceof Error
+          ? err.message
+          : "原因不明のエラーが発生しました";
+      setSaveError(`保存に失敗しました: ${message}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: "40px" }}>
+      <button
+        onClick={() => router.push(`/children/${childId}`)}
+        style={{ marginBottom: "16px" }}
+      >
+        ← 子供詳細へ戻る
+      </button>
+
+      <div style={{ marginBottom: "16px" }}>
+        <h1 style={{ margin: "0 0 8px" }}>今日の学習</h1>
+        <p style={{ margin: 0, color: "#475569" }}>{today}</p>
+      </div>
+
+      {status === "loading" && <p>Loading...</p>}
+
+      {status === "error" && (
+        <div style={{ display: "grid", gap: "12px" }}>
+          <p>読み込みに失敗しました: {error?.message ?? "不明なエラー"}</p>
+          <button onClick={fetchDaily}>再取得</button>
+        </div>
+      )}
+
+      {status === "success" && (
+        <div style={{ display: "grid", gap: "16px" }}>
+          {tasks.length === 0 ? (
+            <p>タスクがありません</p>
+          ) : (
+            <div style={{ display: "grid", gap: "12px" }}>
+              {tasks.map((task) => (
+                <div
+                  key={task.task_id}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "auto 1fr auto",
+                    gap: "12px",
+                    alignItems: "center",
+                    border: "1px solid #e2e8f0",
+                    borderRadius: "8px",
+                    padding: "12px 16px",
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={task.checked}
+                    onChange={() => handleToggle(task.task_id)}
+                  />
+                  <div>
+                    <p style={{ margin: 0, fontWeight: 600 }}>
+                      {task.subject} {task.name}
+                    </p>
+                  </div>
+                  <input
+                    type="number"
+                    min={0}
+                    value={task.minutes}
+                    onChange={(event) =>
+                      handleMinutesChange(task.task_id, event.target.value)
+                    }
+                    disabled={!task.checked}
+                    style={{ width: "80px" }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {saveError ? (
+            <p style={{ color: "#dc2626", margin: 0 }}>{saveError}</p>
+          ) : null}
+          <button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving..." : "保存"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/children/[childId]/page.tsx
+++ b/src/app/children/[childId]/page.tsx
@@ -195,7 +195,7 @@ export default function ChildDetailPage() {
           )}
 
           <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
-            <button disabled>
+            <button onClick={() => router.push(`/children/${child.id}/daily`)}>
               今日の学習
             </button>
             <button disabled>


### PR DESCRIPTION
## 概要
子供ごとの「今日の学習」画面を追加し、daily-view の表示と daily 保存（PUT）を実装しました。

## 変更内容
- `/children/[childId]/daily` を追加
  - 本日の日付（YYYY-MM-DD）で daily-view を取得して表示
  - タスクごとに checkbox / minutes 編集を提供
  - 保存時はチェック済みのみ items に入れて `PUT /daily` を実行
  - 保存後に daily-view を再取得して画面を同期
  - token無し/401時は token をクリアして `/login` へリダイレクト
  - ローディング/エラー表示あり
- 子供詳細（/children/[childId]）の「今日の学習」ボタンを有効化し、
  `/children/[childId]/daily` へ遷移するように変更

## 動作確認
1. `/login` でログイン
2. `/children/[childId]` → 「今日の学習」へ遷移
3. daily-view が表示されること
4. checkbox / minutes を変更して「保存」できること
5. 保存後に再取得され、表示が更新されること
6. token無し/401時に `/login` に戻ること

## 変更ファイル
- src/app/children/[childId]/daily/page.tsx
- src/app/children/[childId]/page.tsx