### PR TITLE
Daily 画面にカレンダーを追加

### DIFF
--- a/src/app/children/[childId]/daily/page.tsx
+++ b/src/app/children/[childId]/daily/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { apiFetch, ApiError } from "@/lib/api";
 import { clearToken, getToken } from "@/lib/auth";
 
@@ -21,33 +21,82 @@ type TaskState = DailyTask & {
   checked: boolean;
 };
 
+type CalendarStatus = "white" | "green" | "yellow" | "red";
+
+type CalendarSummary = {
+  days: { date: string; status: CalendarStatus }[];
+};
+
 type Status = "idle" | "loading" | "success" | "error";
 
 type ErrorInfo = {
   message: string;
 };
 
+const formatDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const parseDate = (value: string) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return null;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const parsed = new Date(year, month, day);
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== month ||
+    parsed.getDate() !== day
+  ) {
+    return null;
+  }
+  return parsed;
+};
+
+const getMonthRange = (year: number, month: number) => {
+  const from = formatDate(new Date(year, month, 1));
+  const endDate = new Date(year, month + 1, 0);
+  const to = formatDate(endDate);
+  return { from, to, lastDay: endDate.getDate() };
+};
+
 export default function DailyPage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const childId = params?.childId;
   const token = useMemo(() => getToken(), []);
-  const today = useMemo(() => {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = `${now.getMonth() + 1}`.padStart(2, "0");
-    const day = `${now.getDate()}`.padStart(2, "0");
-    return `${year}-${month}-${day}`;
-  }, []);
+  const today = useMemo(() => formatDate(new Date()), []);
+  const dateParam = searchParams?.get("date") ?? "";
+  const selectedDate = dateParam || today;
+  const selectedDateValue = useMemo(
+    () => parseDate(selectedDate),
+    [selectedDate]
+  );
 
   const [status, setStatus] = useState<Status>("idle");
   const [tasks, setTasks] = useState<TaskState[]>([]);
   const [error, setError] = useState<ErrorInfo | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [monthState, setMonthState] = useState(() => {
+    const base = selectedDateValue ?? new Date();
+    return { year: base.getFullYear(), month: base.getMonth() };
+  });
+  const [calendarStatus, setCalendarStatus] = useState<Status>("idle");
+  const [calendarError, setCalendarError] = useState<ErrorInfo | null>(null);
+  const [calendarDays, setCalendarDays] = useState<
+    Record<string, CalendarStatus>
+  >({});
 
   const fetchDaily = useCallback(async () => {
-    if (!token || typeof childId !== "string") {
+    if (!token || typeof childId !== "string" || !selectedDateValue) {
       return;
     }
     setStatus("loading");
@@ -55,7 +104,7 @@ export default function DailyPage() {
 
     try {
       const data = await apiFetch<DailyView>(
-        `/children/${childId}/daily-view?date=${today}`,
+        `/children/${childId}/daily-view?date=${selectedDate}`,
         { token }
       );
       const nextTasks = (data.tasks ?? []).map((task) => ({
@@ -77,7 +126,41 @@ export default function DailyPage() {
       setError({ message });
       setStatus("error");
     }
-  }, [childId, router, today, token]);
+  }, [childId, router, selectedDate, selectedDateValue, token]);
+
+  const fetchCalendar = useCallback(async () => {
+    if (!token || typeof childId !== "string") {
+      return;
+    }
+    setCalendarStatus("loading");
+    setCalendarError(null);
+
+    try {
+      const { from, to } = getMonthRange(monthState.year, monthState.month);
+      const data = await apiFetch<CalendarSummary>(
+        `/children/${childId}/calendar-summary?from=${from}&to=${to}`,
+        { token }
+      );
+      const nextMap: Record<string, CalendarStatus> = {};
+      for (const day of data.days ?? []) {
+        nextMap[day.date] = day.status;
+      }
+      setCalendarDays(nextMap);
+      setCalendarStatus("success");
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        clearToken();
+        router.replace("/login");
+        return;
+      }
+      const message =
+        err instanceof Error
+          ? err.message
+          : "原因不明のエラーが発生しました";
+      setCalendarError({ message });
+      setCalendarStatus("error");
+    }
+  }, [childId, monthState.month, monthState.year, router, token]);
 
   useEffect(() => {
     if (!token) {
@@ -91,8 +174,42 @@ export default function DailyPage() {
       return;
     }
 
+    if (!dateParam) {
+      router.replace(`/children/${childId}/daily?date=${today}`);
+      return;
+    }
+
+    if (!selectedDateValue) {
+      setError({ message: "日付が不正です" });
+      setStatus("error");
+      return;
+    }
+
     void fetchDaily();
-  }, [childId, fetchDaily, router, token]);
+  }, [childId, dateParam, fetchDaily, router, selectedDateValue, today, token]);
+
+  useEffect(() => {
+    if (!selectedDateValue) {
+      return;
+    }
+    const nextYear = selectedDateValue.getFullYear();
+    const nextMonth = selectedDateValue.getMonth();
+    setMonthState((prev) =>
+      prev.year === nextYear && prev.month === nextMonth
+        ? prev
+        : { year: nextYear, month: nextMonth }
+    );
+  }, [selectedDateValue]);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+    if (typeof childId !== "string") {
+      return;
+    }
+    void fetchCalendar();
+  }, [childId, fetchCalendar, token]);
 
   const handleToggle = (taskId: string) => {
     setTasks((prev) =>
@@ -117,7 +234,7 @@ export default function DailyPage() {
   };
 
   const handleSave = async () => {
-    if (!token || typeof childId !== "string") {
+    if (!token || typeof childId !== "string" || !selectedDateValue) {
       return;
     }
     setSaving(true);
@@ -131,13 +248,14 @@ export default function DailyPage() {
           minutes: task.minutes,
         }));
 
-      await apiFetch(`/children/${childId}/daily?date=${today}`, {
+      await apiFetch(`/children/${childId}/daily?date=${selectedDate}`, {
         method: "PUT",
         token,
         body: { items },
       });
 
       await fetchDaily();
+      await fetchCalendar();
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
         clearToken();
@@ -165,70 +283,188 @@ export default function DailyPage() {
 
       <div style={{ marginBottom: "16px" }}>
         <h1 style={{ margin: "0 0 8px" }}>今日の学習</h1>
-        <p style={{ margin: 0, color: "#475569" }}>{today}</p>
+        <p style={{ margin: 0, color: "#475569" }}>{selectedDate}</p>
       </div>
 
-      {status === "loading" && <p>Loading...</p>}
-
-      {status === "error" && (
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(240px, 320px) minmax(0, 1fr)",
+          gap: "24px",
+          alignItems: "start",
+        }}
+      >
         <div style={{ display: "grid", gap: "12px" }}>
-          <p>読み込みに失敗しました: {error?.message ?? "不明なエラー"}</p>
-          <button onClick={fetchDaily}>再取得</button>
-        </div>
-      )}
+          <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+            <button
+              onClick={() =>
+                setMonthState((prev) => {
+                  const date = new Date(prev.year, prev.month - 1, 1);
+                  return { year: date.getFullYear(), month: date.getMonth() };
+                })
+              }
+            >
+              前月
+            </button>
+            <span>
+              {monthState.year}-{`${monthState.month + 1}`.padStart(2, "0")}
+            </span>
+            <button
+              onClick={() =>
+                setMonthState((prev) => {
+                  const date = new Date(prev.year, prev.month + 1, 1);
+                  return { year: date.getFullYear(), month: date.getMonth() };
+                })
+              }
+            >
+              次月
+            </button>
+          </div>
 
-      {status === "success" && (
-        <div style={{ display: "grid", gap: "16px" }}>
-          {tasks.length === 0 ? (
-            <p>タスクがありません</p>
-          ) : (
+          {calendarStatus === "loading" && <p>Loading...</p>}
+          {calendarStatus === "error" && (
+            <div style={{ display: "grid", gap: "8px" }}>
+              <p>
+                読み込みに失敗しました:{" "}
+                {calendarError?.message ?? "不明なエラー"}
+              </p>
+              <button onClick={fetchCalendar}>再取得</button>
+            </div>
+          )}
+          {calendarStatus === "success" && (
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(7, 1fr)",
+                gap: "6px",
+              }}
+            >
+              {(() => {
+                const firstDay = new Date(
+                  monthState.year,
+                  monthState.month,
+                  1
+                ).getDay();
+                const { lastDay } = getMonthRange(
+                  monthState.year,
+                  monthState.month
+                );
+                const cells = [];
+
+                for (let i = 0; i < firstDay; i += 1) {
+                  cells.push(
+                    <div
+                      key={`blank-${i}`}
+                      style={{ minHeight: "36px" }}
+                    />
+                  );
+                }
+
+                for (let day = 1; day <= lastDay; day += 1) {
+                  const dateString = formatDate(
+                    new Date(monthState.year, monthState.month, day)
+                  );
+                  const status = calendarDays[dateString];
+                  const isSelected = dateString === selectedDate;
+                  const background =
+                    status === "green"
+                      ? "#dcfce7"
+                      : status === "yellow"
+                        ? "#fef9c3"
+                        : status === "red"
+                          ? "#fee2e2"
+                          : "#f8fafc";
+                  cells.push(
+                    <button
+                      key={dateString}
+                      onClick={() =>
+                        router.push(
+                          `/children/${childId}/daily?date=${dateString}`
+                        )
+                      }
+                      style={{
+                        padding: "6px 0",
+                        borderRadius: "6px",
+                        border: isSelected ? "2px solid #2563eb" : "1px solid #e2e8f0",
+                        background,
+                        fontWeight: isSelected ? 700 : 400,
+                      }}
+                    >
+                      {day}
+                    </button>
+                  );
+                }
+
+                return cells;
+              })()}
+            </div>
+          )}
+        </div>
+
+        <div>
+          {status === "loading" && <p>Loading...</p>}
+
+          {status === "error" && (
             <div style={{ display: "grid", gap: "12px" }}>
-              {tasks.map((task) => (
-                <div
-                  key={task.task_id}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "auto 1fr auto",
-                    gap: "12px",
-                    alignItems: "center",
-                    border: "1px solid #e2e8f0",
-                    borderRadius: "8px",
-                    padding: "12px 16px",
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={task.checked}
-                    onChange={() => handleToggle(task.task_id)}
-                  />
-                  <div>
-                    <p style={{ margin: 0, fontWeight: 600 }}>
-                      {task.subject} {task.name}
-                    </p>
-                  </div>
-                  <input
-                    type="number"
-                    min={0}
-                    value={task.minutes}
-                    onChange={(event) =>
-                      handleMinutesChange(task.task_id, event.target.value)
-                    }
-                    disabled={!task.checked}
-                    style={{ width: "80px" }}
-                  />
-                </div>
-              ))}
+              <p>読み込みに失敗しました: {error?.message ?? "不明なエラー"}</p>
+              <button onClick={fetchDaily}>再取得</button>
             </div>
           )}
 
-          {saveError ? (
-            <p style={{ color: "#dc2626", margin: 0 }}>{saveError}</p>
-          ) : null}
-          <button onClick={handleSave} disabled={saving}>
-            {saving ? "Saving..." : "保存"}
-          </button>
+          {status === "success" && (
+            <div style={{ display: "grid", gap: "16px" }}>
+              {tasks.length === 0 ? (
+                <p>タスクがありません</p>
+              ) : (
+                <div style={{ display: "grid", gap: "12px" }}>
+                  {tasks.map((task) => (
+                    <div
+                      key={task.task_id}
+                      style={{
+                        display: "grid",
+                        gridTemplateColumns: "auto 1fr auto",
+                        gap: "12px",
+                        alignItems: "center",
+                        border: "1px solid #e2e8f0",
+                        borderRadius: "8px",
+                        padding: "12px 16px",
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={task.checked}
+                        onChange={() => handleToggle(task.task_id)}
+                      />
+                      <div>
+                        <p style={{ margin: 0, fontWeight: 600 }}>
+                          {task.subject} {task.name}
+                        </p>
+                      </div>
+                      <input
+                        type="number"
+                        min={0}
+                        value={task.minutes}
+                        onChange={(event) =>
+                          handleMinutesChange(task.task_id, event.target.value)
+                        }
+                        disabled={!task.checked}
+                        style={{ width: "80px" }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {saveError ? (
+                <p style={{ color: "#dc2626", margin: 0 }}>{saveError}</p>
+              ) : null}
+              <button onClick={handleSave} disabled={saving}>
+                {saving ? "Saving..." : "保存"}
+              </button>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
Daily 画面にカレンダーを追加し、日付切替によって過去・当日の学習内容を
表示・編集・保存できるようにしました。

## 実装内容
### 1. 日付切替対応
- `/children/[childId]/daily?date=YYYY-MM-DD`
- date query を状態として管理
- 日付クリック時に router.push で date を更新
- date 変更時に daily-view を再取得

### 2. カレンダー表示（MVP）
- 月表示（YYYY-MM）
- 「前月」「次月」ボタンで月切替
- 7列グリッドの月カレンダー
- 選択中の日付を枠線で強調表示

### 3. カレンダー色分け
- `GET /calendar-summary?from&to` を使用
- status に応じて色分け表示
  - white: 未来日
  - red: 未達成
  - yellow: 一部達成
  - green: 全達成

### 4. Daily 編集・保存
- daily-view のタスク一覧表示（checkbox + minutes）
- チェックONのみ保存対象
- 保存時に `PUT /daily?date=YYYY-MM-DD` を呼び出し
- 保存後は再取得して画面同期

### 5. 安全対策
- token 無し → /login リダイレクト
- 401 → token クリア → /login
- ローディング・エラー表示あり
- 再試行可能

## 動作確認
1. `/children/[childId]/daily` を開く
   - date query が無い場合は当日がセットされる
2. カレンダーの日付をクリック
   - URL の date が切り替わり daily が更新される
3. checkbox / minutes を変更して保存
   - 保存後に再取得され、状態が反映される
4. calendar-summary に基づき色が正しく表示される
5. 前月・次月切替ができること

## 変更ファイル
- src/app/children/[childId]/daily/page.tsx
- src/app/children/[childId]/page.tsx（遷移ボタン）

## 関連
- API 側の 1日ズレ修正 PR（calendar-summary / daily）